### PR TITLE
Add double-conversion, snappy to run dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "mapd-core-cpu" %}
 {% set version = "4.6.1" %}
-{% set sha256 = "06020a9ca43590b23722608c5cfe8ac933d94169927e07f21b2814657a9d8a5d" %}
+{% set sha256 = "c20273674c1b407820f813032be01697e9a6f122cfb3454410ee1c23b7f009d0" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not linux]
 
 requirements:
@@ -44,7 +44,9 @@ requirements:
     - thrift-cpp >=0.11.0
     - ncurses
   run:
+    - snappy  # required for mapd-core > 4.5.0
     - boost-cpp >=1.68
+    - double-conversion
     - libgdal
     - glog
     - gflags


### PR DESCRIPTION
Resolves missing library issue mentioned at

https://github.com/omnisci/mapd-core/issues/334#issuecomment-486382917

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
